### PR TITLE
Wait Cursor is still left if you encounter an error on the Login Screen

### DIFF
--- a/Maestro.Login/WaitCursor.cs
+++ b/Maestro.Login/WaitCursor.cs
@@ -64,7 +64,7 @@ namespace Maestro.Login
         /// </summary>
         public void Dispose()
         {
-            Dispose(false);
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
Wait Cursor is still left if you encounter an error as "can not connect to server" on the Login Screen.
This will fix it if I understand this right :)